### PR TITLE
🐛 argument가 빈값인 경우 default argument 객체를 추가한다

### DIFF
--- a/src/templates/api-request-function.ejs
+++ b/src/templates/api-request-function.ejs
@@ -31,13 +31,14 @@ const streamConfig = {
 
 const requestFunctionArgumentsCode = [...request.parameters.arguments.all, streamConfig.callback.arguments].filter(Boolean).join(", ");
 const requestFunctionArgumentsTypeCode = [`${moduleConfig.apiParametersTypeName}["${request.functionName}"]`, streamConfig.callback.typeExr].filter(Boolean).join(" & ");
+const hasRequestArgs = routeConfig.request.parameters.signatures.required.length > 0;
 %>
 
 /**
 <%~ _.compact([routeDocs.lines, routeDocs.streamDescription]).join('\n') %>
 
 */
-async <%~ request.functionName %>({<%~ requestFunctionArgumentsCode %>}: <%~ requestFunctionArgumentsTypeCode %>) {
+async <%~ request.functionName %>({<%~ requestFunctionArgumentsCode %>}: <%~ requestFunctionArgumentsTypeCode %><%~ hasRequestArgs ? '' : ' = {}' %>) {
     const instance = kyInstance ?? this.instance;
     <%~ codegenConfig.createSchema && request.schema.expression ? `const validatedPayload = validateSchema(${request.schema.expression}, payload);` : '' %>
 


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

⚠️ **버그 수정**: API 요청 함수에서 필수 파라미터가 없는 경우 TypeScript 타입 에러 발생

API 요청 함수 생성 시 필수 파라미터가 없는 엔드포인트(예: `GET /health`, `GET /version` 등)에서 함수 호출 시 빈 객체 `{}`를 전달해야 하는 상황에서 TypeScript 타입 에러가 발생하는 문제를 해결했습니다.

**문제 상황:**
```typescript
// 생성된 코드 (수정 전)
async getHealth({}: TApiRequestParameters["getHealth"]) {
  // 함수 호출 시 빈 객체를 반드시 전달해야 함
}

// 사용 시 타입 에러 발생
api.getHealth(); // ❌ Expected 1 arguments, but got 0
```

✔️ Related issues #

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

API 요청 함수 템플릿에서 필수 파라미터가 없는 경우 기본값을 설정하여 함수 호출을 선택적으로 만들었습니다.

### 🔑 Key changes - 주요 변화

**1. 파라미터 유무 검사 로직 추가**
- `hasRequestArgs` 변수를 통해 필수 파라미터 존재 여부 확인
- `routeConfig.request.parameters.signatures.required.length > 0` 조건으로 판단

**2. 조건부 기본값 설정**
- 필수 파라미터가 없는 경우 `= {}` 기본값 추가
- 필수 파라미터가 있는 경우 기존 동작 유지

**수정된 템플릿 코드:**
```ejs
const hasRequestArgs = routeConfig.request.parameters.signatures.required.length > 0;

async <%~ request.functionName %>({<%~ requestFunctionArgumentsCode %>}: <%~ requestFunctionArgumentsTypeCode %><%~ hasRequestArgs ? '' : ' = {}' %>) {
```

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

**Before (수정 전):**
```typescript
// 필수 파라미터가 없는 API 함수
async getHealth({}: TApiRequestParameters["getHealth"]) {
  // ...
}

// 호출 시 반드시 빈 객체 전달 필요
api.getHealth({}); // ✅ 작동하지만 불편함
api.getHealth();   // ❌ TypeScript 에러
```

**After (수정 후):**
```typescript
// 필수 파라미터가 없는 API 함수 (기본값 추가)
async getHealth({}: TApiRequestParameters["getHealth"] = {}) {
  // ...
}

// 호출 시 파라미터 생략 가능
api.getHealth();   // ✅ 정상 작동
api.getHealth({}); // ✅ 기존 방식도 계속 지원
```

**필수 파라미터가 있는 경우 (기존 동작 유지):**
```typescript
// 필수 파라미터가 있는 API 함수
async getUserById({userId}: TApiRequestParameters["getUserById"]) {
  // ...
}

// 파라미터 필수 전달 (변화 없음)
api.getUserById({userId: 123}); // ✅ 정상 작동
api.getUserById();              // ❌ 여전히 에러 (의도된 동작)
```

## 💬 코멘트 [#](#comments) <span id="comments"></span>
